### PR TITLE
Fix links in Documentation/Specification

### DIFF
--- a/pages/specification.md
+++ b/pages/specification.md
@@ -32,7 +32,7 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_core).
 | 3.1.2          | [Online][core_3.1.2_online], [PDF][core_3.1.2_pdf] |
 
 [core_3.1.5_pdf]: https://github.com/rsmp-nordic/rsmp_core
-[core_3.1.5_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.5/rst/rsmp.rst
+[core_3.1.5_online]: https://rsmp-nordic.github.io/rsmp_core/
 
 [core_3.1.4_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.4/rsmp-spec-3.1.4.pdf
 [core_3.1.4_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.4/rst/rsmp.rst

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -31,7 +31,7 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_core).
 | 3.1.3          | [Online][core_3.1.3_online], [PDF][core_3.1.3_pdf] |
 | 3.1.2          | [Online][core_3.1.2_online], [PDF][core_3.1.2_pdf] |
 
-[core_3.1.5_pdf]: https://github.com/rsmp-nordic/rsmp_core
+[core_3.1.5_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.5/rsmp-spec-3.1.5.pdf
 [core_3.1.5_online]: https://rsmp-nordic.github.io/rsmp_core/
 
 [core_3.1.4_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.4/rsmp-spec-3.1.4.pdf

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -54,7 +54,7 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lig
 | 1.0.14         | [GitHub][tlc_1.0.14_github], [Excel][tlc_1.0.14_excel] |
 | 1.0.13         | [GitHub][tlc_1.0.13_github], [Excel][tlc_1.0.13_excel] |
 
-[tlc_1.0.15_pdf]: hhttps://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/sxl-tlc-1.0.15.pdf
+[tlc_1.0.15_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/sxl-tlc-1.0.15.pdf
 [tlc_1.0.15_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/SXL_Traffic_Controller_ver_1_0_15-2020-10-30.xlsx
 [tlc_1.0.15_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/
 

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -40,7 +40,7 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_core).
 [core_3.1.3_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.3/rsmp-spec-3.1.3.pdf
 [core_3.1.3_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.3/rst/rsmp.rst
 
-[core_3.1.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.3/rsmp-spec-3.1.3.pdf
+[core_3.1.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.3/rsmp-spec-3.1.2.pdf
 [core_3.1.2_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.2/rst/rsmp.rst
 
 

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -41,7 +41,7 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_core).
 [core_3.1.3_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.3/rst/rsmp.rst
 
 [core_3.1.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.3/rsmp-spec-3.1.3.pdf
-[core_3.1.2_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.3/rst/rsmp.rst
+[core_3.1.2_online]: https://github.com/rsmp-nordic/rsmp_core/blob/v3.1.2/rst/rsmp.rst
 
 
 ## Traffic Light Controller SXL

--- a/pages/tools.md
+++ b/pages/tools.md
@@ -16,7 +16,7 @@ This include both GUI and command-line tools for validation and interacting with
 See all our [GitHub repositories](https://github.com/rsmp-nordic).
 
 ## RSMP Simulator
-The [RSMP Simulator ](https://rsmp-nordic.github.io/rsmp_validator) is an Windows application written in C#, which can by used for manual testing of RSMP implementations.
+The [RSMP Simulator ](https://github.com/rsmp-nordic/rsmp_simulator) is an Windows application written in C#, which can by used for manual testing of RSMP implementations.
 
 ![RSMP Simulator](/assets/images/simulator_1.0.1.5.png)
 


### PR DESCRIPTION
- [x] Fix link to Documentation/Specification/Core 3.1.5 Online
- [x] Fix link to Documentation/Specification/Core 3.1.5 PDF
- [x] Fix link to Documentation/Specification/Core 3.1.2 Online
- [x] Fix link to Documentation/Specification/Core 3.1.2 PDF
- [x] Fix link to Documentation/Specification/SXL 1.0.15 PDF
- [x] Fix link to Tools/RSMP Simulator